### PR TITLE
Fix bug in getting last modified timestamp

### DIFF
--- a/USING_GRADLE.md
+++ b/USING_GRADLE.md
@@ -1,0 +1,39 @@
+# Using Gradle to Build the project
+
+This project uses gradle to install external dependencies, build the project (jar files), and execute tests.
+
+## Gradle Version
+
+The version of gradle required is Gradle 4.6, or as specified in `/gradle/wrapper/gradle-wrapper.properties`.
+
+## Run tasks using gradlew instead of gradle
+
+Run `./gradlew` instead of the globally installed `gradle` on your machine to execute gradle tasks.
+
+This ensures that the correct version of gradle is used, and also downloads the required version of gradle.
+
+## Tasks
+
+### Build buildJavaCommonsCore
+
+Run `./gradlew buildJavaCommonsCore` to build the JavaCommonsCore module.
+
+### Build the jar packages
+
+Run `./gradlew jar` to build the project and package as a jar.
+
+Run `./gradlew shadowJar` to build the project and package as a shadow jar (dependencies are shaded)
+
+Run `./gradlew fatJar` to build the project and package as a fat jar (dependencies are included, and not shaded)
+
+Run `./gradlew buildAll` to build all 3 jars (jar, shadow jar, and fat jar).
+
+Run `./gradlew testAndBuildAll` to run full test suite and build all 3 jars (jar, shadow jar, and fat jar).
+
+## Setting  up the project in IntelliJ
+1. Right click "settings.gradle" and click "Import Gradle Project"
+2. In the Gradle Tool Window, click the wrench, and then "Gradle Settings"
+3. Check "Download external annotations for dependencies" - this will allow code hinting to work
+4. Set "Use Gradle from" to "'gradle-wrapper.properties' file" to make sure it runs the correct version of gradle
+
+

--- a/src/main/java/picoded/dstack/mongodb/MongoDB_FileWorkspaceMap.java
+++ b/src/main/java/picoded/dstack/mongodb/MongoDB_FileWorkspaceMap.java
@@ -848,10 +848,14 @@ public class MongoDB_FileWorkspaceMap extends Core_FileWorkspaceMap {
 	public long backend_modifiedTimestamp(final String oid, final String filepath) {
 		// Lets build the query for the "root file"
 		Bson query = Filters.eq("filename", oid + "/" + filepath);
-		
+
 		// Lets prepare the search
-		GridFSFindIterable search = gridFSBucket.find(query).limit(1);
-		
+		GridFSFindIterable search = gridFSBucket.find(query)
+				// GridFS uses an index on the files collection using the filename and uploadDate fields.
+				// Make sure to sort the query by uploadDate descending (-1) to ensure that we get the latest file.
+				.sort((new Document()).append("uploadDate", -1 /* descending*/ ))
+				.limit(1);
+
 		// Lets iterate the search result, and return true on an item
 		try (MongoCursor<GridFSFile> cursor = search.iterator()) {
 			if (cursor.hasNext()) {


### PR DESCRIPTION
There is a bug in getting last modified time stamp. This is because the index for GridFS is filename+uploadDate, so simply querying for exactly one document based on the filename can still result in the query returning older documents. The fix adds `.sort({uploadDate: -1}` to ensure the query returns the most recently uploaded document.

I've also added a readme file for instructions on using gradle for newbies / or forgetful oldies.