### PR TITLE
Fix handling of boolean values in JSql implementation

### DIFF
--- a/src/main/java/picoded/dstack/connector/jsql/JSql_Base.java
+++ b/src/main/java/picoded/dstack/connector/jsql/JSql_Base.java
@@ -130,6 +130,16 @@ public abstract class JSql_Base extends JSql {
 					ps.setDouble(pt + 1, (Double) argObj);
 				} else if (Float.class.isInstance(argObj)) {
 					ps.setFloat(pt + 1, (Float) argObj);
+				} else if (Boolean.class.isInstance(argObj)){
+					boolean bValue = (Boolean) argObj;
+					// note that due to a bug in dstack before 26 Aug 2024,
+					// ... all boolean values were stored as json (Core_DataType.JSON, 31)
+					//     ...thus entry is stored with the values: nVl = NULL, sVL = null, tVl = "true" or "false"
+					//     ... thus, for boolean, we need to query against tVl to support legacy values
+					// ... this bug has been fixed in newer versions of dstack...
+					//     ... where the entry is stored with the values: nVl = 1 or 0, sVL = "true" or "false", tVl = "true" or "false"
+					ps.setString(pt + 1, bValue ? "true" : "false");
+					// ps.setBoolean(pt + 1, (Boolean) argObj); // this does not work, bc this transforms the value to 1/0
 				} else if (Date.class.isInstance(argObj)) {
 					java.sql.Date sqlDate = new java.sql.Date(((Date) argObj).getTime());
 					ps.setDate(pt + 1, sqlDate);

--- a/src/main/java/picoded/dstack/core/Core_DataType.java
+++ b/src/main/java/picoded/dstack/core/Core_DataType.java
@@ -59,7 +59,12 @@ public enum Core_DataType {
 	 * String type
 	 **/
 	STRING(25),
-	
+
+	/**
+	 * Boolean type
+	 */
+	BOOLEAN(26),
+
 	//
 	// Storage types
 	//

--- a/src/main/java/picoded/dstack/jsql/JSql_DataObjectMapUtil.java
+++ b/src/main/java/picoded/dstack/jsql/JSql_DataObjectMapUtil.java
@@ -259,14 +259,36 @@ public class JSql_DataObjectMapUtil {
 		} else if (baseType == Core_DataType.TEXT.getValue()) { // Text
 			return r.get("tVl").getString(pos);
 		}
-		
+
+		//
+		// Boolean value support
+		//
+		if(baseType == Core_DataType.BOOLEAN.getValue()){
+			String tVl = r.getString("tVl");
+			if(tVl.equalsIgnoreCase("true")){
+				return true;
+			}
+			if(tVl.equalsIgnoreCase("false")){
+				return false;
+			}
+			// get the value from nVl
+			int nVl = r.getInt("nVl");
+			if(nVl == 1){
+				return true;
+			}
+			if(nVl == 0){
+				return false;
+			}
+			throw new JSqlException("Invalid boolean value: tVl=" + tVl + ", nVl=" + nVl);
+		}
+
 		//
 		// Binary value
 		//
 		if (baseType == Core_DataType.BINARY.getValue()) {
 			// Older base64 stroage format
 			// return (Base64.getDecoder().decode((String) (r.get("tVl").get(pos))));
-			
+
 			Object rawValue = r.get("rVl").get(pos);
 			if (rawValue instanceof java.sql.Blob) {
 				java.sql.Blob blobData = (java.sql.Blob) rawValue;

--- a/src/main/java/picoded/dstack/jsql/JSql_DataObjectMapUtil.java
+++ b/src/main/java/picoded/dstack/jsql/JSql_DataObjectMapUtil.java
@@ -193,7 +193,15 @@ public class JSql_DataObjectMapUtil {
 			return valueTypeSet(Core_DataType.STRING.getValue(), null, shortenStringValue(value),
 				value.toString(), EmptyArray.BYTE);
 		}
-		
+
+		// Boolean type support
+		// - stores nVl as 1 or 0
+		// - store sVl and tVl as the string value : "true" or "false"
+		if(value instanceof Boolean){
+			return valueTypeSet(Core_DataType.BOOLEAN.getValue(), ((Boolean) value) ? 1 : 0, value.toString(), value.toString(),
+					EmptyArray.BYTE);
+		}
+
 		// Binary type support
 		if (value instanceof byte[]) {
 			return valueTypeSet(Core_DataType.BINARY.getValue(), null, null, null, (byte[]) value);

--- a/src/main/java/picoded/dstack/jsql/JSql_DataObjectMap_QueryBuilder.java
+++ b/src/main/java/picoded/dstack/jsql/JSql_DataObjectMap_QueryBuilder.java
@@ -921,6 +921,16 @@ public class JSql_DataObjectMap_QueryBuilder {
 								"(" + collumnTableAlias + ".sVl IS NULL OR " + replacement.toString() + ")");
 						}
 					}
+				} else if (argObj instanceof Boolean) {
+					// note that due to a bug in dstack before 26 Aug 2024,
+					// ... all boolean values were stored as json (Core_DataType.JSON, 31)
+					//     ...thus entry is stored with the values: nVl = NULL, sVL = null, tVl = "true" or "false"
+					//     ... thus, for boolean, we need to query against tVl to support legacy values
+					// ... this bug has been fixed in newer versions of dstack...
+					//     ... where the entry is stored with the values: nVl = 1 or 0, sVL = "true" or "false", tVl = "true" or "false"
+					replacement = QueryFilter.basicQueryFromTokens(queryArgMap, collumnTableAlias
+						+ ".tVl", toReplace.operatorSymbol(), ":" + toReplace.argumentName() //
+					);
 				}
 				
 				// Unprocessed arg type


### PR DESCRIPTION
JSql implementation has a bug whereby you cannot query boolean values. The cause of the bug is due to missing implementation for handling boolean values, causing all boolean values to be saved as "json" in the database. This means that entries for the boolean values are saved as : `nVl=null, sVl=null, tVl=true/false`. 

I've updated the insert/upsert logic to save boolean values as `nVl=1/0, sVl=true/false, tVl=true/false`.

However, in order to support querying legacy entries that are already saved to the database as json, I've updated the building of preparedstatement for queries to query `tVl=true/false` for boolean values, since `tVl` is set for both legacy and new values. I've added comments above the relevant code block to explain why we don't use preparedStatement.setBoolean instead for future reference.