### PR TITLE
Bugfix for postgres

### DIFF
--- a/src/main/java/picoded/dstack/jsql_json/JsonbUtils.java
+++ b/src/main/java/picoded/dstack/jsql_json/JsonbUtils.java
@@ -103,14 +103,24 @@ public class JsonbUtils {
 					continue;
 				}
 			} else if (v instanceof byte[]) {
-				// Handling of binary data
-				binMap.put(k, v);
+				// Skip binary data in keySet loop; processed below from fullSet
 			} else {
 				// In all other cases, treat it as JSON data
 				// we add it to the jsonMap, if its within the keyset
 				if (keySet.contains(k)) {
 					jsonMap.put(k, v);
 				}
+			}
+		}
+		
+		// Build complete binary map from fullSet to prevent losing existing binary properties during partial updates
+		for (String k : fullSet) {
+			if (k.equalsIgnoreCase("_otm") || k.length() > 64) {
+				continue;
+			}
+			Object v = inMap.get(k);
+			if (v instanceof byte[] && v != null && v != ObjectToken.NULL) {
+				binMap.put(k, v);
 			}
 		}
 		

--- a/src/main/java/picoded/dstack/jsql_json/PostgresJsonb_DataObjectMap.java
+++ b/src/main/java/picoded/dstack/jsql_json/PostgresJsonb_DataObjectMap.java
@@ -214,17 +214,32 @@ public class PostgresJsonb_DataObjectMap extends Core_DataObjectMap {
 		// Curent timestamp
 		long now = JSql_DataObjectMapUtil.getCurrentTimestamp();
 		
-		// // Ensure GUID is registered
-		// sqlObj.upsert( //
-		// 	dataStorageTable, //
-		// 	new String[] { "oID" }, //
-		// 	new Object[] { _oid }, //
-		// 	new String[] { "uTm", "data", "bData" }, //
-		// 	new Object[] { now, dataPair.getLeft(), dataPair.getRight() }, //
-		// 	new String[] { "cTm", "eTm" }, //
-		// 	new Object[] { now, 0 }, //
-		// 	null // The only misc col, is pKy, which is being handled by DB
-		// 	);
+		// Determine which keys are being deleted/removed (explicitly null or ObjectToken.NULL)
+		String updateDataSql = dataStorageTable + ".data||EXCLUDED.data";
+		Set<String> keysToProcess = keys;
+		if (keysToProcess == null) {
+			keysToProcess = fullMap.keySet();
+		}
+		
+		java.util.List<String> deletedKeys = new java.util.ArrayList<>();
+		for (String k : keysToProcess) {
+			if (k.equalsIgnoreCase("oid") || k.equalsIgnoreCase("_oid") || k.equalsIgnoreCase("_otm")) {
+				continue;
+			}
+			Object v = fullMap.get(k);
+			if (v == null || v == picoded.core.common.ObjectToken.NULL) {
+				deletedKeys.add(k);
+			}
+		}
+		
+		if (!deletedKeys.isEmpty()) {
+			StringBuilder sb = new StringBuilder();
+			sb.append("(").append(updateDataSql).append(")");
+			for (String dk : deletedKeys) {
+				sb.append(" - '").append(dk.replace("'", "''")).append("'");
+			}
+			updateDataSql = sb.toString();
+		}
 		
 		// Perform the upsert command
 		sqlObj.update_raw( //
@@ -233,7 +248,7 @@ public class PostgresJsonb_DataObjectMap extends Core_DataObjectMap {
 				"VALUES ( ?, ?, ?, ?, ?::jsonb, ? ) " + //
 				"ON CONFLICT ( oID ) DO UPDATE SET " + //
 				"uTm=EXCLUDED.uTm, " + //
-				"data=" + dataStorageTable + ".data||EXCLUDED.data, " + //
+				"data=" + updateDataSql + ", " + //
 				"bData=EXCLUDED.bData", new Object[] { //
 			_oid, now, now, 0, dataPair.getLeft(), dataPair.getRight() //
 			});


### PR DESCRIPTION
## Bug

There are two failing tests for postgres, these are the raw logs:

```
picoded.dstack.jsql_json.postgres.JSql_Json_DataObjectMap_Postgres_test > removePropertyViaDataObject_saveAll FAILED
    java.lang.AssertionError

picoded.dstack.jsql_json.postgres.JSql_Json_DataObjectMap_Postgres_test > removePropertyViaDataObject_saveDelta FAILED
    java.lang.AssertionError
```

They indicate `DataObject.saveAll` and `DataObject.saveDelta` fail to save deleted properties when using Postgres backend.

## Diagnosis

> Here's the AI diagnosis of the bug

When a user calls `testObject.remove("prop")` and saves the object using `.saveDelta()` or `.saveAll()`, the backend is expected to remove `"prop"`  from the JSON column in the database. However, in `PostgresJsonb_DataObjectMap.DataObjectRemoteDataMap_update`, updates are applied via a native `ON CONFLICT` upsert with the following `DO UPDATE` clause:

```sql
data = dataStorageTable.data || EXCLUDED.data
 ```         

The issue: 

In PostgreSQL/CockroachDB, the JSONB concatenation operator `||` merges two JSONB documents. Since the deleted keys are omitted from `EXCLUDED.data` (serialized as `null` or skipped), the concatenation operator `||` retains their old values from the left-hand operand (`dataStorageTable.data`) instead of deleting them.

Additionally, under partial saves (`saveDelta()`), if a non-binary field was modified, `serializeDataMap` would only process keys within the delta `keySet`, causing `binMap` (and thus `bData`) to serialize to `null` and inadvertently drop any existing binary properties on conflict update.

## Fix

> Here's how the AI fixed the bug

1. Dynamic JSONB Subtraction (`PostgresJsonb_DataObjectMap.java`):

• We now analyze the list of keys to be processed and detect if any keys are deleted/removed (their value is `null` or `ObjectToken.NULL` in fullMap).   
• If there are deleted keys, we dynamically append PostgreSQL's jsonb subtraction operator (`- 'key'`) to the on-conflict upsert statement, e.g.:      
```
data = (dataStorageTable.data || EXCLUDED.data) - 'removed_key_1' - 'removed_key_2'
```
          
This cleanly and safely drops the removed keys from the merged JSONB document.

2. Robust Binary Preservation (`JsonbUtils.java`):

• Modified `serializeDataMap` to always build the binary map (`binMap`) from the complete set of existing fields (`fullSet`) instead of the partial delta `keySet`. This guarantees that existing binary properties are always preserved during partial updates to JSON properties.
